### PR TITLE
SourceFile.span() should include last char when end offset omitted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.5.2
+
+* `SourceFile.span()` now goes to the end of the file by default, rather than
+  ending one character before the end of the file. This matches the documented
+  behavior.
+
 # 1.5.1
 
 * Produce better source span highlights for multi-line spans that cover the

--- a/lib/src/file.dart
+++ b/lib/src/file.dart
@@ -88,7 +88,7 @@ class SourceFile {
   ///
   /// If [end] isn't passed, it defaults to the end of the file.
   FileSpan span(int start, [int end]) {
-    if (end == null) end = length - 1;
+    if (end == null) end = length;
     return new _FileSpan(this, start, end);
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: source_span
-version: 1.5.1
+version: 1.5.2-dev
 
 description: A library for identifying source spans and locations.
 author: Dart Team <misc@dartlang.org>

--- a/test/file_test.dart
+++ b/test/file_test.dart
@@ -157,7 +157,7 @@ zip zap zop""", url: "bar.dart").span(10, 11);
     test("end defaults to the end of the file", () {
       var span = file.span(5);
       expect(span.start, equals(file.location(5)));
-      expect(span.end, equals(file.location(file.length - 1)));
+      expect(span.end, equals(file.location(file.length)));
     });
   });
 
@@ -251,6 +251,10 @@ zip zap zop""", url: "bar.dart").span(10, 11);
   group("FileSpan", () {
     test("text returns a substring of the source", () {
       expect(file.span(8, 15).text, equals("baz\nwhi"));
+    });
+
+    test("text includes the last char when end is defaulted to EOF", () {
+      expect(file.span(29).text, equals("p zap zop"));
     });
 
     test("context contains the span's text", () {


### PR DESCRIPTION
According to the documentation, calling `SourceFile.span(start, [end])` without an explicit end offset should create a span that extends to the end of the file:

> If [end] isn't passed, it defaults to the end of the file.

Currently, the implementation returns a span with an end offset of `length - 1`, but because the end offset is always exclusive, this actually excludes the last character in the file. There wasn't an existing test for this case – the closest was one for `getText()` which correctly handles an omitted end offset.

In other words, I would expect the following to be true:

```dart
file.span(10).text == file.getText(10);
```

but they are not; the LHS here would be missing the last character.

---

This PR adjusts the `span()` implementation to return `length` instead of `length - 1` so that the last character is not excluded in this scenario and adds a test that verifies as much. Given that this package is used in a lot of places, I'll defer to the package maintainer as to whether or not this change could introduce any range errors or unexpected behavior for consumers, but at the very least the rest of the tests in this package were unaffected.

@nex3 