### PR TITLE
Fix a highlighting bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.5.5
+
+* Fix a bug where `FileSpan.highlight()` would crash for spans that covered a
+  trailing newline and a single additional empty line.
+
 # 1.5.4
 
 * `FileSpan.highlight()` now properly highlights point spans at the beginning of

--- a/lib/src/highlighter.dart
+++ b/lib/src/highlighter.dart
@@ -161,7 +161,9 @@ class Highlighter {
 
     // The "- 1" here avoids counting the newline itself.
     if (text.codeUnitAt(text.length - 1) == $lf) {
-      return text.length == 1 ? 0 : text.length - text.lastIndexOf("\n", text.length - 2) - 1;
+      return text.length == 1
+          ? 0
+          : text.length - text.lastIndexOf("\n", text.length - 2) - 1;
     } else {
       return text.length - text.lastIndexOf("\n") - 1;
     }

--- a/lib/src/highlighter.dart
+++ b/lib/src/highlighter.dart
@@ -117,6 +117,10 @@ class Highlighter {
       SourceSpanWithContext span) {
     if (!span.context.endsWith("\n")) return span;
 
+    // If there's a full blank line on the end of [span.context], it's probably
+    // significant, so we shouldn't trim it.
+    if (span.text.endsWith("\n\n")) return span;
+
     var context = span.context.substring(0, span.context.length - 1);
     var text = span.text;
     var start = span.start;
@@ -156,9 +160,11 @@ class Highlighter {
     if (text.isEmpty) return 0;
 
     // The "- 1" here avoids counting the newline itself.
-    return text.codeUnitAt(text.length - 1) == $lf
-        ? text.length - text.lastIndexOf("\n", text.length - 2) - 1
-        : text.length - text.lastIndexOf("\n") - 1;
+    if (text.codeUnitAt(text.length - 1) == $lf) {
+      return text.length == 1 ? 0 : text.length - text.lastIndexOf("\n", text.length - 2) - 1;
+    } else {
+      return text.length - text.lastIndexOf("\n") - 1;
+    }
   }
 
   /// Returns whether [span]'s text runs all the way to the end of its context.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: source_span
-version: 1.5.4
+version: 1.5.5
 
 description: A library for identifying source spans and locations.
 author: Dart Team <misc@dartlang.org>

--- a/test/highlight_test.dart
+++ b/test/highlight_test.dart
@@ -120,6 +120,15 @@ zip zap zop
   | ^
   '"""));
     });
+
+    test("on an empty line", () {
+      var file = new SourceFile.fromString("foo\n\nbar");
+      expect(file.location(4).pointSpan().highlight(), equals("""
+  ,
+2 | 
+  | ^
+  '"""));
+    });
   });
 
   test("highlights a single-line file without a newline", () {
@@ -128,6 +137,15 @@ zip zap zop
   ,
 1 | foo bar
   | ^^^^^^^
+  '"""));
+  });
+
+  test("highlights a single empty line", () {
+    expect(new SourceFile.fromString("foo\n\nbar").span(4, 5).highlight(),
+        equals("""
+  ,
+2 | 
+  | ^
   '"""));
   });
 
@@ -275,6 +293,27 @@ bar
       expect(file.span(0, 5).highlight(), equals("""
   ,
 1 | / foo
+2 | \\ 
+  '"""));
+    });
+
+    test("highlights multiple empty lines", () {
+      var file = new SourceFile.fromString("foo\n\n\n\nbar");
+      expect(file.span(4, 7).highlight(), equals("""
+  ,
+2 | / 
+3 | | 
+4 | \\ 
+  '"""));
+    });
+
+    // Regression test for #32
+    test("highlights the end of a line and an empty line", () {
+      var file = new SourceFile.fromString("foo\n\n");
+      expect(file.span(3, 5).highlight(), equals("""
+  ,
+1 |   foo
+  | ,----^
 2 | \\ 
   '"""));
     });


### PR DESCRIPTION
If a span covered a trailing newline and a single additional line, it
went down a code path that resulted in a range error. That code path
has now been fixed.

Closes #32