### PR TITLE
Fix strict inference failures

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,0 +1,3 @@
+analyzer:
+  language:
+    strict-inference: true

--- a/lib/src/file.dart
+++ b/lib/src/file.dart
@@ -53,12 +53,12 @@ class SourceFile {
   ///
   /// Use [new SourceFile.fromString] instead.
   @Deprecated("Will be removed in 2.0.0")
-  SourceFile(String text, {url}) : this.decoded(text.runes, url: url);
+  SourceFile(String text, {Object url}) : this.decoded(text.runes, url: url);
 
   /// Creates a new source file from [text].
   ///
   /// [url] may be either a [String], a [Uri], or `null`.
-  SourceFile.fromString(String text, {url})
+  SourceFile.fromString(String text, {Object url})
       : this.decoded(text.codeUnits, url: url);
 
   /// Creates a new source file from a list of decoded code units.
@@ -70,7 +70,7 @@ class SourceFile {
   /// surrogate pairs. **This behavior is deprecated**. For
   /// forwards-compatibility, callers should only pass in characters less than
   /// or equal to `0xFFFF`.
-  SourceFile.decoded(Iterable<int> decodedChars, {url})
+  SourceFile.decoded(Iterable<int> decodedChars, {Object url})
       : url = url is String ? Uri.parse(url) : url,
         _decodedChars = new Uint32List.fromList(decodedChars.toList()) {
     for (var i = 0; i < _decodedChars.length; i++) {
@@ -362,15 +362,16 @@ class _FileSpan extends SourceSpanMixin implements FileSpan {
     return span;
   }
 
-  bool operator ==(other) {
+  bool operator ==(Object other) {
     if (other is! FileSpan) return super == other;
+    final fileSpan = other as FileSpan;
     if (other is! _FileSpan) {
-      return super == other && sourceUrl == other.sourceUrl;
+      return super == other && sourceUrl == fileSpan.sourceUrl;
     }
-
-    return _start == other._start &&
-        _end == other._end &&
-        sourceUrl == other.sourceUrl;
+    final _fileSpan = other as _FileSpan;
+    return _start == _fileSpan._start &&
+        _end == _fileSpan._end &&
+        sourceUrl == _fileSpan.sourceUrl;
   }
 
   // Eliminates dart2js warning about overriding `==`, but not `hashCode`

--- a/lib/src/highlighter.dart
+++ b/lib/src/highlighter.dart
@@ -54,7 +54,7 @@ class Highlighter {
   /// color red). If it's `true`, it indicates that the text should be
   /// highlighted using the default color. If it's `false` or `null`, it
   /// indicates that the text shouldn't be highlighted.
-  factory Highlighter(SourceSpan span, {color}) {
+  factory Highlighter(SourceSpan span, {Object color}) {
     if (color == true) color = colors.RED;
     if (color == false) color = null;
 

--- a/lib/src/location.dart
+++ b/lib/src/location.dart
@@ -42,7 +42,7 @@ class SourceLocation implements Comparable<SourceLocation> {
   /// means that [line] defaults to 0 and [column] defaults to [offset].
   ///
   /// [sourceUrl] may be either a [String], a [Uri], or `null`.
-  SourceLocation(int offset, {sourceUrl, int line, int column})
+  SourceLocation(int offset, {Object sourceUrl, int line, int column})
       : sourceUrl = sourceUrl is String ? Uri.parse(sourceUrl) : sourceUrl,
         offset = offset,
         line = line == null ? 0 : line,
@@ -81,7 +81,7 @@ class SourceLocation implements Comparable<SourceLocation> {
     return offset - other.offset;
   }
 
-  bool operator ==(other) =>
+  bool operator ==(Object other) =>
       other is SourceLocation &&
       sourceUrl == other.sourceUrl &&
       offset == other.offset;
@@ -94,6 +94,6 @@ class SourceLocation implements Comparable<SourceLocation> {
 /// A base class for source locations with [offset], [line], and [column] known
 /// at construction time.
 class SourceLocationBase extends SourceLocation {
-  SourceLocationBase(int offset, {sourceUrl, int line, int column})
+  SourceLocationBase(int offset, {Object sourceUrl, int line, int column})
       : super(offset, sourceUrl: sourceUrl, line: line, column: column);
 }

--- a/lib/src/location_mixin.dart
+++ b/lib/src/location_mixin.dart
@@ -37,7 +37,7 @@ abstract class SourceLocationMixin implements SourceLocation {
     return offset - other.offset;
   }
 
-  bool operator ==(other) =>
+  bool operator ==(Object other) =>
       other is SourceLocation &&
       sourceUrl == other.sourceUrl &&
       offset == other.offset;

--- a/lib/src/span.dart
+++ b/lib/src/span.dart
@@ -60,7 +60,7 @@ abstract class SourceSpan implements Comparable<SourceSpan> {
   /// This uses the full range of Unicode characters to highlight the source
   /// span if [glyph.ascii] is `false` (the default), but only uses ASCII
   /// characters if it's `true`.
-  String message(String message, {color});
+  String message(String message, {Object color});
 
   /// Prints the text associated with this span in a user-friendly way.
   ///
@@ -79,7 +79,7 @@ abstract class SourceSpan implements Comparable<SourceSpan> {
   /// This uses the full range of Unicode characters to highlight the source
   /// span if [glyph.ascii] is `false` (the default), but only uses ASCII
   /// characters if it's `true`.
-  String highlight({color});
+  String highlight({Object color});
 }
 
 /// A base class for source spans with [start], [end], and [text] known at

--- a/lib/src/span_exception.dart
+++ b/lib/src/span_exception.dart
@@ -27,7 +27,7 @@ class SourceSpanException implements Exception {
   /// highlight the span's text. If it's `true`, it indicates that the text
   /// should be highlighted using the default color. If it's `false` or `null`,
   /// it indicates that the text shouldn't be highlighted.
-  String toString({color}) {
+  String toString({Object color}) {
     if (span == null) return message;
     return "Error on " + span.message(message, color: color);
   }
@@ -38,7 +38,7 @@ class SourceSpanFormatException extends SourceSpanException
     implements FormatException {
   // This is a getter so that subclasses can override it.
   dynamic get source => _source;
-  final _source;
+  final dynamic _source;
 
   int get offset => span == null ? null : span.start.offset;
 

--- a/lib/src/span_mixin.dart
+++ b/lib/src/span_mixin.dart
@@ -44,7 +44,7 @@ abstract class SourceSpanMixin implements SourceSpan {
     return new SourceSpan(start, end, text);
   }
 
-  String message(String message, {color}) {
+  String message(String message, {Object color}) {
     var buffer = new StringBuffer();
     buffer.write('line ${start.line + 1}, column ${start.column + 1}');
     if (sourceUrl != null) buffer.write(' of ${p.prettyUri(sourceUrl)}');
@@ -59,12 +59,12 @@ abstract class SourceSpanMixin implements SourceSpan {
     return buffer.toString();
   }
 
-  String highlight({color}) {
+  String highlight({Object color}) {
     if (this is! SourceSpanWithContext && this.length == 0) return "";
     return new Highlighter(this, color: color).highlight();
   }
 
-  bool operator ==(other) =>
+  bool operator ==(Object other) =>
       other is SourceSpan && start == other.start && end == other.end;
 
   int get hashCode => start.hashCode + (31 * end.hashCode);

--- a/test/file_test.dart
+++ b/test/file_test.dart
@@ -5,8 +5,8 @@
 import 'package:test/test.dart';
 import 'package:source_span/source_span.dart';
 
-main() {
-  var file;
+void main() {
+  SourceFile file;
   setUp(() {
     file = new SourceFile.fromString("""
 foo bar baz
@@ -296,7 +296,7 @@ zip zap zop
     });
 
     group("union()", () {
-      var span;
+      FileSpan span;
       setUp(() {
         span = file.span(5, 12);
       });
@@ -359,7 +359,7 @@ zip zap zop
     });
 
     group("expand()", () {
-      var span;
+      FileSpan span;
       setUp(() {
         span = file.span(5, 12);
       });

--- a/test/highlight_test.dart
+++ b/test/highlight_test.dart
@@ -8,7 +8,7 @@ import 'package:test/test.dart';
 import 'package:source_span/source_span.dart';
 import 'package:source_span/src/colors.dart' as colors;
 
-main() {
+void main() {
   bool oldAscii;
   setUpAll(() {
     oldAscii = glyph.ascii;
@@ -19,7 +19,7 @@ main() {
     glyph.ascii = oldAscii;
   });
 
-  var file;
+  SourceFile file;
   setUp(() {
     file = new SourceFile.fromString("""
 foo bar baz

--- a/test/location_test.dart
+++ b/test/location_test.dart
@@ -5,8 +5,8 @@
 import 'package:test/test.dart';
 import 'package:source_span/source_span.dart';
 
-main() {
-  var location;
+void main() {
+  SourceLocation location;
   setUp(() {
     location =
         new SourceLocation(15, line: 2, column: 6, sourceUrl: "foo.dart");

--- a/test/span_test.dart
+++ b/test/span_test.dart
@@ -8,7 +8,7 @@ import 'package:term_glyph/term_glyph.dart' as glyph;
 import 'package:source_span/source_span.dart';
 import 'package:source_span/src/colors.dart' as colors;
 
-main() {
+void main() {
   bool oldAscii;
   setUpAll(() {
     oldAscii = glyph.ascii;
@@ -19,7 +19,7 @@ main() {
     glyph.ascii = oldAscii;
   });
 
-  var span;
+  SourceSpan span;
   setUp(() {
     span = new SourceSpan(new SourceLocation(5, sourceUrl: "foo.dart"),
         new SourceLocation(12, sourceUrl: "foo.dart"), "foo bar");

--- a/test/utils_test.dart
+++ b/test/utils_test.dart
@@ -5,7 +5,7 @@
 import 'package:test/test.dart';
 import 'package:source_span/src/utils.dart';
 
-main() {
+void main() {
   group('find line start', () {
     test('skip entries in wrong column', () {
       var context = '0_bb\n1_bbb\n2b____\n3bbb\n';


### PR DESCRIPTION
Annotate implicitly dynamic argument types with `Object`. Fix a few
dynamic calls to first cast.

Change some uninitialized `var` in tests to have a type.

Add `void` return types on test `main` definitions.