### PR TITLE
Revert "Be more efficient with String.fromCharCodes (#44)"

### DIFF
--- a/lib/src/file.dart
+++ b/lib/src/file.dart
@@ -214,7 +214,7 @@ class SourceFile {
   ///
   /// If [end] isn't passed, it defaults to the end of the file.
   String getText(int start, [int end]) =>
-      String.fromCharCodes(_decodedChars, start, end);
+      String.fromCharCodes(_decodedChars.sublist(start, end));
 }
 
 /// A [SourceLocation] within a [SourceFile].


### PR DESCRIPTION
This reverts commit a5f8eadfe16c9479eea2f5328216ab2bb5f21e25.

This caused an unknown issue in rare cases with the test package.