### PR TITLE
Add SourceSpan.subspan()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-# 1.6.1-dev
+# 1.7.0
+
+* Add a `SourceSpan.subspan()` extension method which returns a slice of an
+  existing source span.
 
 # 1.6.0
 

--- a/lib/src/file.dart
+++ b/lib/src/file.dart
@@ -424,7 +424,7 @@ class _FileSpan extends SourceSpanMixin implements FileSpan {
     }
   }
 
-  /// See [SourceSpanExtension.subspan].
+  /// See `SourceSpanExtension.subspan`.
   FileSpan subspan(int start, [int end]) {
     RangeError.checkValidRange(start, end, length);
     if (start == 0 && (end == null || end == length)) return this;
@@ -435,7 +435,7 @@ class _FileSpan extends SourceSpanMixin implements FileSpan {
 // TODO(#52): Move these to instance methods in the next breaking release.
 /// Extension methods on the [FileSpan] API.
 extension FileSpanExtension on FileSpan {
-  /// See [SourceSpanExtension.subspan].
+  /// See `SourceSpanExtension.subspan`.
   FileSpan subspan(int start, [int end]) {
     RangeError.checkValidRange(start, end, length);
     if (start == 0 && (end == null || end == length)) return this;

--- a/lib/src/file.dart
+++ b/lib/src/file.dart
@@ -423,4 +423,25 @@ class _FileSpan extends SourceSpanMixin implements FileSpan {
       return _FileSpan(file, start, end);
     }
   }
+
+  /// See [SourceSpanExtension.subspan].
+  FileSpan subspan(int start, [int end]) {
+    RangeError.checkValidRange(start, end, length);
+    if (start == 0 && (end == null || end == length)) return this;
+    return file.span(_start + start, end == null ? _end : _start + end);
+  }
+}
+
+// TODO(#52): Move these to instance methods in the next breaking release.
+/// Extension methods on the [FileSpan] API.
+extension FileSpanExtension on FileSpan {
+  /// See [SourceSpanExtension.subspan].
+  FileSpan subspan(int start, [int end]) {
+    RangeError.checkValidRange(start, end, length);
+    if (start == 0 && (end == null || end == length)) return this;
+
+    final startOffset = this.start.offset;
+    return file.span(
+        startOffset + start, end == null ? this.end.offset : startOffset + end);
+  }
 }

--- a/lib/src/span.dart
+++ b/lib/src/span.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:charcode/charcode.dart';
 import 'package:path/path.dart' as p;
 import 'package:term_glyph/term_glyph.dart' as glyph;
 
@@ -179,4 +180,56 @@ extension SourceSpanExtension on SourceSpan {
               primaryColor: primaryColor,
               secondaryColor: secondaryColor)
           .highlight();
+
+  /// Returns a span from [start] characters (inclusive) to [end] characters
+  /// (exclusive) after the beginning of this span.
+  SourceSpan subspan(int start, [int end]) {
+    RangeError.checkValidRange(
+        start, end, length); // TODO: is this the right argument order?
+    if (start == 0 && (end == null || end == length)) return this;
+
+    final text = this.text;
+    final startLocation = this.start;
+    var line = startLocation.line;
+    var column = startLocation.column;
+
+    // Adjust [line] and [column] as necessary if the character at [i] in [text]
+    // is a newline.
+    void consumeCodePoint(int i) {
+      final codeUnit = text.codeUnitAt(i);
+      if (codeUnit == $lf ||
+          // A carriage return counts as a newline, but only if it's not
+          // followed by a line feed.
+          (codeUnit == $cr &&
+              (i + 1 == text.length || text.codeUnitAt(i + 1) != $lf))) {
+        line += 1;
+        column = 0;
+      } else {
+        column += 1;
+      }
+    }
+
+    for (var i = 0; i < start; i++) {
+      consumeCodePoint(i);
+    }
+
+    final newStartLocation = SourceLocation(startLocation.offset + start,
+        sourceUrl: sourceUrl, line: line, column: column);
+
+    SourceLocation newEndLocation;
+    if (end == null || end == length) {
+      newEndLocation = this.end;
+    } else if (end == start) {
+      newEndLocation = newStartLocation;
+    } else if (end != null && end != length) {
+      for (var i = start; i < end; i++) {
+        consumeCodePoint(i);
+      }
+      newEndLocation = SourceLocation(startLocation.offset + end,
+          sourceUrl: sourceUrl, line: line, column: column);
+    }
+
+    return SourceSpan(
+        newStartLocation, newEndLocation, text.substring(start, end));
+  }
 }

--- a/lib/src/span.dart
+++ b/lib/src/span.dart
@@ -181,11 +181,10 @@ extension SourceSpanExtension on SourceSpan {
               secondaryColor: secondaryColor)
           .highlight();
 
-  /// Returns a span from [start] characters (inclusive) to [end] characters
+  /// Returns a span from [start] code units (inclusive) to [end] code units
   /// (exclusive) after the beginning of this span.
   SourceSpan subspan(int start, [int end]) {
-    RangeError.checkValidRange(
-        start, end, length); // TODO: is this the right argument order?
+    RangeError.checkValidRange(start, end, length);
     if (start == 0 && (end == null || end == length)) return this;
 
     final text = this.text;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: source_span
-version: 1.6.1-dev
+version: 1.7.0
 
 description: A library for identifying source spans and locations.
 homepage: https://github.com/dart-lang/source_span


### PR DESCRIPTION
This is useful when a span may cover multiple logical tokens, and a
user wants to single out a single specific token.