### PR TITLE
Work around flow analysis bug

### DIFF
--- a/lib/src/highlighter.dart
+++ b/lib/src/highlighter.dart
@@ -293,7 +293,8 @@ class Highlighter {
             : _secondaryColor;
     var foundCurrent = false;
     for (var tmp in highlightsByColumn) {
-      final highlight = tmp; // Work around https://github.com/dart-lang/sdk/issues/43136
+      // Work around https://github.com/dart-lang/sdk/issues/43136
+      final highlight = tmp;
       final startLine = highlight?.span.start.line;
       final endLine = highlight?.span.end.line;
       if (current != null && highlight == current) {

--- a/lib/src/highlighter.dart
+++ b/lib/src/highlighter.dart
@@ -293,7 +293,7 @@ class Highlighter {
             : _secondaryColor;
     var foundCurrent = false;
     for (var tmp in highlightsByColumn) {
-      var highlight = tmp; // Work around https://github.com/dart-lang/sdk/issues/43136
+      final highlight = tmp; // Work around https://github.com/dart-lang/sdk/issues/43136
       final startLine = highlight?.span.start.line;
       final endLine = highlight?.span.end.line;
       if (current != null && highlight == current) {

--- a/lib/src/highlighter.dart
+++ b/lib/src/highlighter.dart
@@ -292,7 +292,8 @@ class Highlighter {
             ? _primaryColor
             : _secondaryColor;
     var foundCurrent = false;
-    for (var highlight in highlightsByColumn) {
+    for (var tmp in highlightsByColumn) {
+      var highlight = tmp; // Work around https://github.com/dart-lang/sdk/issues/43136
       final startLine = highlight?.span.start.line;
       final endLine = highlight?.span.end.line;
       if (current != null && highlight == current) {
@@ -326,9 +327,9 @@ class Highlighter {
             }, color: openedOnThisLineColor);
             openedOnThisLine = true;
             openedOnThisLineColor ??=
-                highlight!.isPrimary ? _primaryColor : _secondaryColor;
+                highlight.isPrimary ? _primaryColor : _secondaryColor;
           } else if (endLine == line.number &&
-              highlight!.span.end.column == line.text.length) {
+              highlight.span.end.column == line.text.length) {
             _buffer.write(highlight.label == null
                 ? glyph.glyphOrAscii('└', '\\')
                 : vertical);


### PR DESCRIPTION
Flow analysis currently has a bug preventing for-each loop variables
from being properly promoted in the presence of closures
(https://github.com/dart-lang/sdk/issues/43136); as a result of this
bug the source_span package had two non-null assertions that ought to
have been unnecessary.

I'm preparing a fix for that bug, however if I land it as is, it will
cause the front end to emit errors saying "Operand of null-aware
operation '!' has type '_Highlight' which excludes null"; this in turn
will cause SDK bot breakages (since source_span is imported into the
SDK repo).

So, in order to land the fix, we need to first update the source_span
package to work around the bug; this change does that by allocating a
temporary variable (which *is* promoted correctly).

Once the fix for https://github.com/dart-lang/sdk/issues/43136 lands,
I will make a follow-up change that deletes the temporary variable.