### PR TITLE
Reverts https://github.com/dart-lang/source_span/pull/59, remove unnecessary `!`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: dart
 
 dart:
-- dev
+- be/raw/latest
 
 jobs:
   include:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.8.0-nullsafety.1
+
+* Fixes a newly recognized unnecessary null check to remove warnings.
+
 # 1.8.0-nullsafety
 
 * Migrate to null safety.

--- a/lib/src/highlighter.dart
+++ b/lib/src/highlighter.dart
@@ -326,9 +326,9 @@ class Highlighter {
             }, color: openedOnThisLineColor);
             openedOnThisLine = true;
             openedOnThisLineColor ??=
-                highlight!.isPrimary ? _primaryColor : _secondaryColor;
+                highlight.isPrimary ? _primaryColor : _secondaryColor;
           } else if (endLine == line.number &&
-              highlight!.span.end.column == line.text.length) {
+              highlight.span.end.column == line.text.length) {
             _buffer.write(highlight.label == null
                 ? glyph.glyphOrAscii('└', '\\')
                 : vertical);

--- a/lib/src/highlighter.dart
+++ b/lib/src/highlighter.dart
@@ -292,9 +292,7 @@ class Highlighter {
             ? _primaryColor
             : _secondaryColor;
     var foundCurrent = false;
-    for (var tmp in highlightsByColumn) {
-      // Work around https://github.com/dart-lang/sdk/issues/43136
-      final highlight = tmp;
+    for (var highlight in highlightsByColumn) {
       final startLine = highlight?.span.start.line;
       final endLine = highlight?.span.end.line;
       if (current != null && highlight == current) {
@@ -328,9 +326,9 @@ class Highlighter {
             }, color: openedOnThisLineColor);
             openedOnThisLine = true;
             openedOnThisLineColor ??=
-                highlight.isPrimary ? _primaryColor : _secondaryColor;
+                highlight!.isPrimary ? _primaryColor : _secondaryColor;
           } else if (endLine == line.number &&
-              highlight.span.end.column == line.text.length) {
+              highlight!.span.end.column == line.text.length) {
             _buffer.write(highlight.label == null
                 ? glyph.glyphOrAscii('└', '\\')
                 : vertical);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,12 +1,12 @@
 name: source_span
-version: 1.8.0-nullsafety
+version: 1.8.0-nullsafety.1
 
 description: A library for identifying source spans and locations.
 homepage: https://github.com/dart-lang/source_span
 
 environment:
   # This must remain a tight constraint until nnbd is stable
-  sdk: '>=2.10.0-0 <2.10.0'
+  sdk: '>=2.10.0-137.0.dev <2.10.0'
 
 dependencies:
   charcode: '>=1.2.0-nullsafety <1.2.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ homepage: https://github.com/dart-lang/source_span
 
 environment:
   # This must remain a tight constraint until nnbd is stable
-  sdk: '>=2.10.0-137.0.dev <2.10.0'
+  sdk: '>=2.10.0-137.0 <2.10.0'
 
 dependencies:
   charcode: '>=1.2.0-nullsafety <1.2.0'


### PR DESCRIPTION
Reverts https://github.com/dart-lang/source_span/pull/59 and removes now unnecessary `!`s.

This requires a newer sdk than is available on dev, so run tests on be/raw/latest for now.

The dart version in flutter should already be compatible with this version.