### PR TITLE
Revert the revert of the flow analysis workaround 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: dart
 
 dart:
-- be/raw/latest
+- dev
 
 jobs:
   include:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 1.8.0-nullsafety.2-dev
+
+* Revert unnecessary null check fix (sdk fix wont land in 2.10 stable).
+
+# 1.8.0-nullsafety.1
+
+* Fixes a newly recognized unnecessary null check to remove warnings.
+
 # 1.8.0-nullsafety
 
 * Migrate to null safety.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,3 @@
-# 1.8.0-nullsafety.1
-
-* Fixes a newly recognized unnecessary null check to remove warnings.
-
 # 1.8.0-nullsafety
 
 * Migrate to null safety.

--- a/lib/src/highlighter.dart
+++ b/lib/src/highlighter.dart
@@ -292,7 +292,9 @@ class Highlighter {
             ? _primaryColor
             : _secondaryColor;
     var foundCurrent = false;
-    for (var highlight in highlightsByColumn) {
+    for (var tmp in highlightsByColumn) {
+      // Work around https://github.com/dart-lang/sdk/issues/43136
+      final highlight = tmp;
       final startLine = highlight?.span.start.line;
       final endLine = highlight?.span.end.line;
       if (current != null && highlight == current) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,12 +1,12 @@
 name: source_span
-version: 1.8.0-nullsafety.1
+version: 1.8.0-nullsafety
 
 description: A library for identifying source spans and locations.
 homepage: https://github.com/dart-lang/source_span
 
 environment:
   # This must remain a tight constraint until nnbd is stable
-  sdk: '>=2.10.0-137.0 <2.10.0'
+  sdk: '>=2.10.0-0 <2.10.0'
 
 dependencies:
   charcode: '>=1.2.0-nullsafety <1.2.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,12 +1,12 @@
 name: source_span
-version: 1.8.0-nullsafety
+version: 1.8.0-nullsafety.2-dev
 
 description: A library for identifying source spans and locations.
 homepage: https://github.com/dart-lang/source_span
 
 environment:
   # This must remain a tight constraint until nnbd is stable
-  sdk: '>=2.10.0-0 <2.10.0'
+  sdk: '>=2.10.0-0.0 <2.10.0'
 
 dependencies:
   charcode: '>=1.2.0-nullsafety <1.2.0'


### PR DESCRIPTION
The 2.10 stable sdk it turns out will not have the sdk fix.