### PR TITLE
prep to release to unblock flutter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
-# 1.8.0-nullsafety.2-dev
+# 1.8.0-nullsafety.2
 
 * Revert unnecessary null check fix (sdk fix wont land in 2.10 stable).
+* Allow 2.10 stable and 2.11 dev sdks. 
 
 # 1.8.0-nullsafety.1
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,12 +1,12 @@
 name: source_span
-version: 1.8.0-nullsafety.2-dev
+version: 1.8.0-nullsafety.2
 
 description: A library for identifying source spans and locations.
 homepage: https://github.com/dart-lang/source_span
 
 environment:
   # This must remain a tight constraint until nnbd is stable
-  sdk: '>=2.10.0-0.0 <2.10.0'
+  sdk: '>=2.10.0-0.0 <2.11.0'
 
 dependencies:
   charcode: '>=1.2.0-nullsafety <1.2.0'


### PR DESCRIPTION
See https://github.com/flutter/flutter/issues/66287, this version works with old/new dart sdks