### PR TITLE
Remove workaround for SDK bug.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.8.0-nullsafety.3
+
+* Remove workaround for https://github.com/dart-lang/sdk/issues/43136, which is
+  now fixed.
+
 # 1.8.0-nullsafety.2
 
 * Revert unnecessary null check fix (sdk fix wont land in 2.10 stable).

--- a/lib/src/highlighter.dart
+++ b/lib/src/highlighter.dart
@@ -292,9 +292,7 @@ class Highlighter {
             ? _primaryColor
             : _secondaryColor;
     var foundCurrent = false;
-    for (var tmp in highlightsByColumn) {
-      // Work around https://github.com/dart-lang/sdk/issues/43136
-      final highlight = tmp;
+    for (var highlight in highlightsByColumn) {
       final startLine = highlight?.span.start.line;
       final endLine = highlight?.span.end.line;
       if (current != null && highlight == current) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,12 +1,12 @@
 name: source_span
-version: 1.8.0-nullsafety.2
+version: 1.8.0-nullsafety.3-dev
 
 description: A library for identifying source spans and locations.
 homepage: https://github.com/dart-lang/source_span
 
 environment:
   # This must remain a tight constraint until nnbd is stable
-  sdk: '>=2.10.0-0.0 <2.11.0'
+  sdk: '>=2.11.0-0.0 <2.11.0'
 
 dependencies:
   charcode: '>=1.2.0-nullsafety <1.2.0'


### PR DESCRIPTION
Now that https://github.com/dart-lang/sdk/issues/43136 is fixed, the
workaround is no longer needed.