### PR TITLE
Bump SDK constraints for pub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.8.0-nullsafety.4
+
+* Update SDK constraints to `>=2.12.0-0 <3.0.0` based on beta release
+  guidelines.
+
 # 1.8.0-nullsafety.3
 
 * Remove workaround for https://github.com/dart-lang/sdk/issues/43136, which is

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,12 +1,11 @@
 name: source_span
-version: 1.8.0-nullsafety.3
+version: 1.8.0-nullsafety.4
 
 description: A library for identifying source spans and locations.
 homepage: https://github.com/dart-lang/source_span
 
 environment:
-  # This must remain a tight constraint until nnbd is stable
-  sdk: '>=2.11.0-0.0 <2.12.0'
+  sdk: ">=2.12.0-0.0 <3.0.0"
 
 dependencies:
   charcode: '>=1.2.0-nullsafety <1.2.0'


### PR DESCRIPTION
Use a 2.12.0 lower bound since pub does not understand allowed
experiments for earlier versions.

Use a 3.0.0 upper bound to avoid a warning in pub and to give some
flexibility in publishing for stable.