### PR TITLE
Remove dependency on package:charcode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# 1.8.0-nullsafety.5-dev
+
 # 1.8.0-nullsafety.4
 
 * Update SDK constraints to `>=2.12.0-0 <3.0.0` based on beta release

--- a/lib/src/charcode.dart
+++ b/lib/src/charcode.dart
@@ -1,0 +1,15 @@
+// Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// "Carriage return" control character.
+const int $cr = 0x0D;
+
+/// "Line feed" control character.
+const int $lf = 0x0A;
+
+/// Space character.
+const int $space = 0x20;
+
+/// "Horizontal Tab" control character, common name.
+const int $tab = 0x09;

--- a/lib/src/highlighter.dart
+++ b/lib/src/highlighter.dart
@@ -4,11 +4,11 @@
 
 import 'dart:math' as math;
 
-import 'package:charcode/charcode.dart';
 import 'package:collection/collection.dart';
 import 'package:path/path.dart' as p;
 import 'package:term_glyph/term_glyph.dart' as glyph;
 
+import 'charcode.dart';
 import 'colors.dart' as colors;
 import 'location.dart';
 import 'span.dart';

--- a/lib/src/span.dart
+++ b/lib/src/span.dart
@@ -2,10 +2,10 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:charcode/charcode.dart';
 import 'package:path/path.dart' as p;
 import 'package:term_glyph/term_glyph.dart' as glyph;
 
+import 'charcode.dart';
 import 'file.dart';
 import 'highlighter.dart';
 import 'location.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: source_span
-version: 1.8.0-nullsafety.4
+version: 1.8.0-nullsafety.5-dev
 
 description: A library for identifying source spans and locations.
 homepage: https://github.com/dart-lang/source_span
@@ -8,7 +8,6 @@ environment:
   sdk: ">=2.12.0-0.0 <3.0.0"
 
 dependencies:
-  charcode: '>=1.2.0-nullsafety <1.2.0'
   collection: '>=1.15.0-nullsafety <1.15.0'
   path: '>=1.8.0-nullsafety <1.8.0'
   term_glyph: '>=1.2.0-nullsafety <1.2.0'


### PR DESCRIPTION
Copy in the charcode constants that are used in this package to a
private library.