### PR TITLE
Add trim methods to SourceSpan

### DIFF
--- a/lib/src/span.dart
+++ b/lib/src/span.dart
@@ -190,4 +190,19 @@ extension SourceSpanExtension on SourceSpan {
     final locations = subspanLocations(this, start, end);
     return SourceSpan(locations[0], locations[1], text.substring(start, end));
   }
+
+  /// Removes leading whitespace and trailing whitespace from [text] and adjust
+  /// [start] and [end].
+  SourceSpan trim() {
+    final trimmed = text.trim();
+    final index = text.indexOf(trimmed);
+    return subspan(index, index + trimmed.length);
+  }
+
+  /// As [trim], but only removes leading whitespace.
+  SourceSpan trimLeft() =>
+      subspan(text.length - text.trimLeft().length, text.length);
+
+  /// As [trim], but only removes trailing whitespace.
+  SourceSpan trimRight() => subspan(0, text.trimRight().length);
 }

--- a/lib/src/span.dart
+++ b/lib/src/span.dart
@@ -200,8 +200,7 @@ extension SourceSpanExtension on SourceSpan {
   }
 
   /// As [trim], but only removes leading whitespace.
-  SourceSpan trimLeft() =>
-      subspan(text.length - text.trimLeft().length, text.length);
+  SourceSpan trimLeft() => subspan(length - text.trimLeft().length, length);
 
   /// As [trim], but only removes trailing whitespace.
   SourceSpan trimRight() => subspan(0, text.trimRight().length);

--- a/test/span_test.dart
+++ b/test/span_test.dart
@@ -429,4 +429,35 @@ ${colors.blue}  '${colors.none}"""));
       expect(span, isNot(equals(other)));
     });
   });
+
+  group('trim', () {
+    setUp(() {
+      span = SourceSpan(
+        SourceLocation(0, line: 0, column: 0),
+        SourceLocation(14, line: 1, column: 8),
+        'hey \n foo\n bar',
+      ).subspan(3, 11);
+    });
+
+    test('trim()', () {
+      final result = span.trim();
+      expect(result.start, equals(SourceLocation(6, line: 1, column: 1)));
+      expect(result.end, equals(SourceLocation(9, line: 1, column: 4)));
+      expect(result.text, equals('foo'));
+    });
+
+    test('trimLeft()', () {
+      final result = span.trimLeft();
+      expect(result.start, equals(SourceLocation(6, line: 1, column: 1)));
+      expect(result.end, equals(SourceLocation(11, line: 2, column: 1)));
+      expect(result.text, equals('foo\n '));
+    });
+
+    test('trimRight()', () {
+      final result = span.trimRight();
+      expect(result.start, equals(SourceLocation(3, line: 0, column: 3)));
+      expect(result.end, equals(SourceLocation(9, line: 1, column: 4)));
+      expect(result.text, equals(' \n foo'));
+    });
+  });
 }

--- a/test/span_test.dart
+++ b/test/span_test.dart
@@ -434,7 +434,7 @@ ${colors.blue}  '${colors.none}"""));
     setUp(() {
       span = SourceSpan(
         SourceLocation(0, line: 0, column: 0),
-        SourceLocation(14, line: 1, column: 8),
+        SourceLocation(14, line: 2, column: 4),
         'hey \n foo\n bar',
       ).subspan(3, 11);
     });


### PR DESCRIPTION
This is useful when trim the `text` field of a `span`