### PR TITLE
remove uses of runtimeType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
+# 1.9.2
+
+* Remove the use of `runtimeType` from toString methods (#85).
+
 # 1.9.1
 
 * Properly handle multi-line labels for multi-span highlights.
-
 * Populate the pubspec `repository` field.
 
 # 1.9.0

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -45,6 +45,7 @@ linter:
   - list_remove_unrelated_type
   - no_adjacent_strings_in_list
   - no_duplicate_case_values
+  - no_runtimeType_toString
   - non_constant_identifier_names
   - null_closures
   - omit_local_variable_types

--- a/lib/src/location.dart
+++ b/lib/src/location.dart
@@ -92,7 +92,7 @@ class SourceLocation implements Comparable<SourceLocation> {
   int get hashCode => (sourceUrl?.hashCode ?? 0) + offset;
 
   @override
-  String toString() => '<$runtimeType: $offset $toolString>';
+  String toString() => '<SourceLocation: $offset $toolString>';
 }
 
 /// A base class for source locations with [offset], [line], and [column] known

--- a/lib/src/location_mixin.dart
+++ b/lib/src/location_mixin.dart
@@ -51,5 +51,5 @@ abstract class SourceLocationMixin implements SourceLocation {
   int get hashCode => (sourceUrl?.hashCode ?? 0) + offset;
 
   @override
-  String toString() => '<$runtimeType: $offset $toolString>';
+  String toString() => '<SourceLocation: $offset $toolString>';
 }

--- a/lib/src/span_mixin.dart
+++ b/lib/src/span_mixin.dart
@@ -80,5 +80,5 @@ abstract class SourceSpanMixin implements SourceSpan {
   int get hashCode => Object.hash(start, end);
 
   @override
-  String toString() => '<$runtimeType: from $start to $end "$text">';
+  String toString() => '<SourceSpan: from $start to $end "$text">';
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: source_span
-version: 1.9.1
+version: 1.9.2
 description: A library for identifying source spans and locations.
 repository: https://github.com/dart-lang/source_span
 

--- a/test/location_test.dart
+++ b/test/location_test.dart
@@ -53,6 +53,11 @@ void main() {
     });
   });
 
+  test('toString contains the class type', () {
+    final location = SourceLocation(15, line: 2, column: 6);
+    expect(location.toString(), startsWith('<SourceLocation'));
+  });
+
   test('distance returns the absolute distance between locations', () {
     final other = SourceLocation(10, sourceUrl: 'foo.dart');
     expect(location.distance(other), equals(5));

--- a/test/span_test.dart
+++ b/test/span_test.dart
@@ -378,6 +378,11 @@ ${colors.blue}  '${colors.none}"""));
     });
   });
 
+  test('toString contains the class type', () {
+    final span = SourceSpan(SourceLocation(5), SourceLocation(5), '');
+    expect(span.toString(), startsWith('<SourceSpan'));
+  });
+
   group('compareTo()', () {
     test('sorts by start location first', () {
       final other = SourceSpan(SourceLocation(6, sourceUrl: 'foo.dart'),


### PR DESCRIPTION
- remove uses of `runtimeType` from the codebase (these were all in toString methods; the uses there were changed to just report the main parent type)
- fix https://github.com/dart-lang/source_span/issues/85
