### PR TITLE
Add public access to a SourceFile's code units

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 1.10.0
+## 1.10.0
 
 * Add a `SourceFile.codeUnits` property.
 * Require Dart 2.18

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
-# 1.9.2-dev
+# 1.10.0
 
+* Add a `SourceFile.codeUnits` property.
 * Require Dart 2.18
 * Add an API usage example in `example/`.
 

--- a/lib/src/file.dart
+++ b/lib/src/file.dart
@@ -32,7 +32,15 @@ class SourceFile {
   /// the file.
   final _lineStarts = <int>[0];
 
-  /// The code points of the characters in the file.
+  /// The code units of the characters in the file.
+  ///
+  /// If this was constructed with the deprecated [new SourceFile] constructor,
+  /// this will instead contain the code _points_ of the characters in the file
+  /// (so characters above 2^16 are represented as individual integers rather
+  /// than surrogate pairs).
+  List<int> get codeUnits => _decodedChars;
+
+  /// The code units of the characters in this file.
   final Uint32List _decodedChars;
 
   /// The length of the file in characters.

--- a/lib/src/file.dart
+++ b/lib/src/file.dart
@@ -34,7 +34,7 @@ class SourceFile {
 
   /// The code units of the characters in the file.
   ///
-  /// If this was constructed with the deprecated [new SourceFile] constructor,
+  /// If this was constructed with the deprecated `SourceFile()` constructor,
   /// this will instead contain the code _points_ of the characters in the file
   /// (so characters above 2^16 are represented as individual integers rather
   /// than surrogate pairs).

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: source_span
-version: 1.9.2-dev
+version: 1.10.0
 description: >-
   Provides a standard representation for source code locations and spans.
 repository: https://github.com/dart-lang/source_span


### PR DESCRIPTION
This makes it possible to efficiently reparse information from around
a `FileSpan`, such as to expand it through surrounding whitespace
characters. Otherwise, a caller would have to call `getText()` which
can be very expensive in a tight loop.